### PR TITLE
Adds datetimevalue type for model building

### DIFF
--- a/aiogcd/orm/properties/__init__.py
+++ b/aiogcd/orm/properties/__init__.py
@@ -11,3 +11,4 @@ from .jsonvalue import JsonValue
 from .doublevalue import DoubleValue
 from .keyvalue import KeyValue
 from .anyvalue import AnyValue
+from .datetimevalue import DatetimeValue

--- a/aiogcd/orm/properties/datetimevalue.py
+++ b/aiogcd/orm/properties/datetimevalue.py
@@ -1,0 +1,28 @@
+from .value import Value
+from ...connector.timestampvalue import TimestampValue
+import re
+
+RFC3339_RE = re.compile(r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:(?:[\+\-]\d{2}:\d{2})|Z)$')
+
+
+class DatetimeValue(Value):
+
+    def check_value(self, value):
+        if not isinstance(value, TimestampValue):
+            raise TypeError(
+                'Expecting an value of type \'TimestampValue\' for property '
+                '{!r} but received type {!r}.'
+                .format(self.name, value.__class__.__name__))
+
+        if not RFC3339_RE.search(str(value)):
+            raise TypeError(
+                'Expecting a value of type \'str\' in RFC3339 datetime format '
+                'for property {!r}.'
+                .format(self.name))
+
+    def set_value(self, model, value):
+        if isinstance(value, str):
+            value = TimestampValue(value)
+
+        self.check_value(value)
+        super().set_value(model, value)

--- a/aiogcd/orm/properties/datetimevalue.py
+++ b/aiogcd/orm/properties/datetimevalue.py
@@ -2,7 +2,7 @@ from .value import Value
 from ...connector.timestampvalue import TimestampValue
 import re
 
-RFC3339_RE = re.compile(r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:(?:[\+\-]\d{2}:\d{2})|Z)$')
+RFC3339_RE = re.compile(r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:(?:[\+\-]\d{2}:\d{2})|Z)$')  # nopep8
 
 
 class DatetimeValue(Value):


### PR DESCRIPTION
Allows building models with `DatetimeValue` properties.  Verifies that values are RFC3339 formatted as per Google DataStore's [Timestamp spec](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#timestamp) (See also [Entity spec](https://cloud.google.com/datastore/docs/concepts/entities)).

Timestamp properties can be set using `str` or `TimestampValue`:

```python
...
from aiogcd.orm.properties import DatetimeValue
from aiogcd.connector.timestampvalue import TimestampValue


class User(GcdModel):
    name = StringValue()
    age = IntegerValue(required=False)
    created = DatetimeValue()


async def insert_alice():
    # Create a key. As name/id we are allowed to use None since this is
    # a new key. Gcd will assign a new id to the key.
    key = Key('User', None, project_id=gcd.project_id)

    now = datetime.now(timezone.utc).isoformat()
    ts = TimestampValue(str(now))
    
    # Create a new User entity.
    # these 2 declarations are the same
    alice = User(name='Alice', age=26, key=key, created=str(now))
    alice = User(name='Alice', age=26, key=key, created=ts)
```