### PR TITLE
Adds get_as_tuple method to Path

### DIFF
--- a/aiogcd/connector/key.py
+++ b/aiogcd/connector/key.py
@@ -68,6 +68,9 @@ class Key:
         self.path = \
             Path(pairs=zip(*[iter(args)]*2)) if path is None else path
 
+    def get_path(self):
+        return self.path.get_as_tuple()
+
     def __repr__(self):
         return self.path.__repr__()
 

--- a/aiogcd/connector/path.py
+++ b/aiogcd/connector/path.py
@@ -42,7 +42,7 @@ class Path:
         return self._path.__getitem__(item)
 
     def __repr__(self):
-        return str(tuple((pe.kind, pe.id) for pe in self._path))
+        return str(self.get_as_tuple())
 
     def get_dict(self):
         return {'path': [pe.get_dict() for pe in self._path]}
@@ -53,3 +53,8 @@ class Path:
         for path_element in self._path:
             n += path_element.byte_size
         return n
+
+    def get_as_tuple(self):
+        """Returns a tuple of pairs (tuples) representing the key path of an
+        entity. Useful for composing entities with a specific ancestor."""
+        return tuple((pe.kind, pe.id) for pe in self._path)


### PR DESCRIPTION
Adds a method for obtaining a path as a tuple. This can be used to construct new paths with explicit ancestors.