### PR TITLE
Adds get_parent method to key class

### DIFF
--- a/aiogcd/connector/key.py
+++ b/aiogcd/connector/key.py
@@ -158,7 +158,7 @@ class Key:
 
         return project_id, path
 
-    def parent(self):
+    def get_parent(self):
         parent_pairs = self.path.get_as_tuple()[:-1]
         parent_path = Path(pairs=parent_pairs)
         return Key(path=parent_path, project_id=self.project_id)

--- a/aiogcd/connector/key.py
+++ b/aiogcd/connector/key.py
@@ -157,3 +157,8 @@ class Key:
                 raise BufferDecodeError('corrupt')
 
         return project_id, path
+
+    def parent(self):
+        parent_pairs = self.path.get_as_tuple()[:-1]
+        parent_path = Path(pairs=parent_pairs)
+        return Key(path=parent_path, project_id=self.project_id)


### PR DESCRIPTION
Simple `key.parent()` method to mirror ndb a bit.  Easily implemented on the fly (it's not much code), so it's a convenience function only.