### PR TITLE
fixed infinite loop on service account token acquiring

### DIFF
--- a/aiogcd/connector/service_account_token.py
+++ b/aiogcd/connector/service_account_token.py
@@ -110,7 +110,9 @@ class ServiceAccountToken():
                 timeout=60
             )
 
-        return await response.json()
+	    json = await response.json()	
+        
+        return json
 
     def _generate_assertion(self):
         payload = self._make_gcloud_oauth_body(


### PR DESCRIPTION
in about 30% of cases calling await response.json() as well as response.read() directly during service account token acquisition resulted in infinite loading time.

I think it was caused by calling response outside of with statement when session is already closed
I am not really good yet in aiohttp but mentioned changes solve problem


