### PR TITLE
Added option to include None values in `serializable_dict` method

### DIFF
--- a/aiogcd/connector/utils.py
+++ b/aiogcd/connector/utils.py
@@ -77,7 +77,7 @@ def value_from_dict(val):
             return data
     if 'entityValue' in val:
         return {
-            k: value_from_dict(v) 
+            k: value_from_dict(v)
             for k, v in val['entityValue'].get('properties', {}).items()}
 
     raise TypeError('Unexpected or unsupported value: {}'.format(val))

--- a/aiogcd/orm/model.py
+++ b/aiogcd/orm/model.py
@@ -151,11 +151,11 @@ class GcdModel(Entity, metaclass=_ModelClass):
     async def get_entities(cls, gcd, offset=None, limit=None):
         return await Filter(cls).get_entities(gcd, offset, limit)
 
-    def serializable_dict(self, key_as=None):
+    def serializable_dict(self, key_as=None, include_none=False):
         data = {
             prop.name: self._serialize_value(prop.get_value(self))
             for prop in self.model_props.values()
-            if prop.get_value(self) is not None
+            if include_none or prop.get_value(self) is not None
         }
 
         if isinstance(key_as, str):

--- a/aiogcd/orm/model.py
+++ b/aiogcd/orm/model.py
@@ -152,7 +152,7 @@ class GcdModel(Entity, metaclass=_ModelClass):
         return await Filter(cls).get_entities(gcd, offset, limit)
 
     def serializable_dict(self, key_as=None, include_none=False):
-        """Serialize a GcdModel.
+        """Serialize a GcdModel to a Python dict.
 
         :param key_as: If key_as is set to a string value, then the key string
                        will be added to the dict. (default is None)

--- a/aiogcd/orm/model.py
+++ b/aiogcd/orm/model.py
@@ -152,6 +152,13 @@ class GcdModel(Entity, metaclass=_ModelClass):
         return await Filter(cls).get_entities(gcd, offset, limit)
 
     def serializable_dict(self, key_as=None, include_none=False):
+        """Serialize a GcdModel.
+
+        :param key_as: If key_as is set to a string value, then the key string
+                       will be added to the dict. (default is None)
+        :param include_none: If include_none is set to True, None values will
+                             be included in the dict. (default is False)
+        """
         data = {
             prop.name: self._serialize_value(prop.get_value(self))
             for prop in self.model_props.values()

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ twine upload --repository pypi dist/aiogcd-X.X.X.tar.gz
 import setuptools
 from distutils.core import setup, Extension
 
-VERSION = '0.11.10'
+VERSION = '0.11.11'
 
 install_requires = [
     'aiohttp>=2',


### PR DESCRIPTION
When calling the `serializable_dict` method on a model, all `None` values are removed from the dict.
It might be useful to have them included in the dict.

Added the option `include_none` to the `serializable_dict` method which by default is set to `False`. 
This way the behavior will be equal for existing code, but makes it possible to get the `None` values when this is preferred. 